### PR TITLE
Update requirements.txt

### DIFF
--- a/bundles/quarto-stock-report-python/requirements.txt
+++ b/bundles/quarto-stock-report-python/requirements.txt
@@ -6,6 +6,6 @@ nbconvert==7.16.1
 ipykernel==6.29.3
 ipywidgets==8.1.2
 
-matplotlib==3.8.3
+matplotlib==3.7.5
 pandas==2.2.1
 yfinance==0.2.37


### PR DESCRIPTION
"quarto-script-python" failed with the following error 
```
ERROR: No matching distribution found for matplotlib==3.8.3
```
Updated the requirements.txt with the available version 3.7.5 